### PR TITLE
Output OAuth URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,11 @@ func main() {
 		clientSecret = viper.GetString("client-secret")
 	}
 
+	fmt.Println("Open the following URL if your browser did not open automatically:")
+ 	fmt.Printf(oauthUrl, clientID)
+ 	fmt.Println()
+	fmt.Println()
+	
 	helper.LaunchBrowser(viper.GetBool("open"), oauthUrl, clientID)
 
 	reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
On WSL, the browser does not automatically open so we need to output the OAuth URL.